### PR TITLE
Bump version and make this work on NVDA 2025.1 beta onward. Note that…

### DIFF
--- a/globalPlugins/typing_settings/__init__.py
+++ b/globalPlugins/typing_settings/__init__.py
@@ -169,38 +169,6 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			config.conf["typing_settings"]["speak_on_protected"] = True
 			message(_("speak passwords on"))
 
-	@script(
-		description = _("Switches between the available speak characters  modes."),
-		category = _("typing settings"),
-gestures=["kb:nvda+2"])
-	def script_speak_characters(self, gesture):
-		current = config.conf["keyboard"]["speakTypedCharacters"]
-		if current ==2:
-			config.conf["keyboard"]["speakTypedCharacters"] = 0
-			message(_("speak typed characters off"))
-		elif current == 1:
-			config.conf["keyboard"]["speakTypedCharacters"] = 2
-			message(_("speak typed characters always"))
-		elif current == 0:
-			config.conf["keyboard"]["speakTypedCharacters"] = 1
-			message(_("speak typed characters only in edit controls"))
-
-	@script(
-		description = _("Switches between the available speak words  modes."),
-		category = _("typing settings"),
-gestures=["kb:nvda+3"])
-	def script_speak_words(self, gesture):
-		current = config.conf["keyboard"]["speakTypedWords"]
-		if current ==2:
-			config.conf["keyboard"]["speakTypedWords"] = 0
-			message(_("speak typed words off"))
-		elif current == 1:
-			config.conf["keyboard"]["speakTypedWords"] = 2
-			message(_("speak typed words always"))
-		elif current == 0:
-			config.conf["keyboard"]["speakTypedWords"] = 1
-			message(_("speak typed words only in edit controls"))
-
 	def terminate(self):
 		RestoreTypingProtected()
 		NVDASettingsDialog.categoryClasses.remove(TypingSettingsPanel)

--- a/manifest.ini
+++ b/manifest.ini
@@ -1,9 +1,9 @@
-name = "typing_settings"
-summary = "typing_settings"
-description = "Provide some options that improve typing on the keyboard"
-author = "Konsta Suurhaukka <konsta.suurhaukka@gmail.com>, abdallah hayder<abd23200@gmail.com>"
+name = "Typing Settings"
+summary = "Typing Settings"
+description = "Provides some options that improve typing on the keyboard"
+author = "abdallah hayder<abd23200@gmail.com>, Konsta Suurhaukka <konsta.suurhaukka@gmail.com>"
 url = https://t.me/+jt3xVn76RGhlZjYy
-version = 0.4
+version = 0.5
 docFileName = readme.html
 minimumNVDAVersion = 2019.3
 lastTestedNVDAVersion = 2025.1


### PR DESCRIPTION
… this version (0.4) does not work with earlier NVDA versions. Removed the combo boxes for character/word speaking as these are integrated to NVDA as of 2025.1 beta.